### PR TITLE
Controlled lists (data type part)

### DIFF
--- a/source/assets/js/modules/profile/controllers/profile.controller.js
+++ b/source/assets/js/modules/profile/controllers/profile.controller.js
@@ -134,6 +134,7 @@ angular.module('locApp.modules.profile.controllers')
         };
         
         var isResource = false;
+        var isProperty = false;
 
         /**
          * @ngdoc function
@@ -148,8 +149,11 @@ angular.module('locApp.modules.profile.controllers')
             if (isResource) {
                 $scope.selectedResource = $scope.sssSelected;
             }
-            else {
+            else if (isProperty) {
                 $scope.selectedProperty = $scope.sssSelected;
+            }
+            else {
+                $scope.selectedDatatype = $scope.sssSelected
             }
         };
 
@@ -193,6 +197,7 @@ angular.module('locApp.modules.profile.controllers')
             $scope.selectData = Vocab.updateChosenProperty(item);
             $scope.sssVocab = {};
             isResource = false;
+            isProperty = true;
             
             //Use a traditional for loop to break out of it when 
             //the proper data is found
@@ -208,6 +213,36 @@ angular.module('locApp.modules.profile.controllers')
             }
             
             $scope.vocabHeader = "Choose Property Template";
+        };
+
+        /**
+         * @ngdoc function
+         * @name updateChosenDatatype
+         * Populates resourceNumber.propertyNumber with the correct data
+         * @param {Number} resourceNumber - the number of the resource template
+         * @param {Number} propertyNumber - the numer of the property template
+         */
+
+        $scope.updateChosenDatatype = function(item) {
+            $scope.selectData = Vocab.updateChosenDatatype(item);
+            $scope.sssVocab = {};
+            isResource = false;
+            isProperty = false;
+            
+            //Use a traditional for loop to break out of it when 
+            //the proper data is found
+            for(var i = 0; i < $scope.selectData.length; i++) {
+                if($scope.selectData[i].value === $scope.selectedDatatype) {
+                    $scope.sssSelected = $scope.selectedDatatype;
+                    $scope.selectVocab();
+                    break;
+                } else {
+                    $scope.vocabData = [];
+                    $scope.vocabDataFull = [];
+                }
+            }
+            
+            $scope.vocabHeader = "Choose Datatype";
         };
 
         /**

--- a/source/assets/js/modules/profile/controllers/profile.controller.js
+++ b/source/assets/js/modules/profile/controllers/profile.controller.js
@@ -242,7 +242,7 @@ angular.module('locApp.modules.profile.controllers')
                 }
             }
             
-            $scope.vocabHeader = "Choose Datatype";
+            $scope.vocabHeader = "Choose Data Type";
         };
 
         /**

--- a/source/assets/js/modules/profile/controllers/profileList.controller.js
+++ b/source/assets/js/modules/profile/controllers/profileList.controller.js
@@ -36,7 +36,7 @@ angular.module('locApp.modules.profile.controllers')
             data: "profiles",
             columnDefs: [
                 {
-                    field:'title', displayName:'Title', width: 160,
+                    field:'title', displayName:'Title', width: 350,
                     cellTemplate: '<a href="#/profile/{{row.entity.versoId}}"  class="pad-cell">{{ row.entity.title }}</a>'
                 },
                 {

--- a/source/assets/js/modules/profile/services/vocab.service.js
+++ b/source/assets/js/modules/profile/services/vocab.service.js
@@ -9,9 +9,11 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
 
     var choosenResource = -1;
     var choosenProperty = -1;
+    var choosenDatatype = -1
 
     var vocabResourceData = [];
     var vocabPropertyData = [];
+    var vocabDatatypeData = [];
     
     var languageList = [];
 
@@ -102,8 +104,50 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         return propertyData;
     };
 
+    var buildDatatypes = function(rdfDatatypes) {
+        var datatypeData = [];
+
+        if(!Array.isArray(rdfDatatypes) && rdfDatatypes !== undefined) {
+            var data = {};
+
+            if(rdfDatatypes.label != null) {
+               data.label = rdfDatatypes.label.__text.toString();
+            }
+            else {
+                data.label = "";
+            }
+
+            data.comment = (rdfDatatypes.comment != null) ? rdfDatatypes.comment.__text.toString() : "";
+            data.uri = rdfDatatypes["_rdf:about"];
+            datatypeData.push(data);
+            return datatypeData;
+        }
+
+        angular.forEach(rdfDatatypes, function(value) {
+            var data = {};
+
+            if(value.label === undefined) {
+                value.label = null;
+            } else if (value.label.__text === undefined) {
+                value.label = null;
+            }
+
+            if(value.label != null) {
+               data.label = value.label.__text.toString();
+            }
+            else {
+                data.label = "";
+            }
+
+            data.comment = (value.comment != null) ? value.comment.__text.toString() : "";
+            data.uri = value["_rdf:about"];
+            datatypeData.push(data);
+        });
+        return datatypeData;
+    };
+
     // Method that will set the vocab data for each list.
-    var _setVocabData = function(name, url, properties, resources) {
+    var _setVocabData = function(name, url, properties, resources, datatypes) {
         var item = $q.defer();
         
         Server.get(url,{},false)
@@ -119,6 +163,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
             // set the local storage with this data
             var resource = {};
             var property = {};
+            var datatype = {};
 
             resource.key = name;
             resource.value = buildResources(xjson.RDF.Class);
@@ -131,8 +176,11 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
             } else {
                 property.value = buildProperties(xjson.RDF.ObjectProperty);
             }
-
             properties.push(property);
+
+            datatype.key = name;
+            datatype.value = buildDatatypes(xjson.RDF.DatatypeProperty);
+            datatypes.push(datatype);
 
             // Resolve the queue
             item.resolve("Finished");
@@ -142,12 +190,14 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
     };
 
     // Method to set the local storage of resource and properties
-    var _setLocalStorage = function(resources, properties) {
+    var _setLocalStorage = function(resources, properties, datatypes) {
         localStorageService.set("resourceReference", resources);
         localStorageService.set("propertyReference", properties);
+        localStorageService.set("datatypeReference", datatypes);
         // Set Vocab data
         vocabResourceData = resources;
         vocabPropertyData = properties;
+        vocabDatatypeData = datatypes;
     };
 
     /**
@@ -169,6 +219,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
             var returnNumber = 0;
             var resources = [];
             var properties = [];
+            var datatypes = [];
 
             // loop through the list of vocabs and gather up the data.
             angular.forEach(response, function(value) {
@@ -177,13 +228,13 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
                 // test that we hvae a key and this isn't a comment.
                 if(value.id != null) {
                     listLength++;
-                    _setVocabData(value.json.label, url, properties, resources)
+                    _setVocabData(value.json.label, url, properties, resources, datatypes)
                         .then(function() {
                             returnNumber++;
 
                             // Set local storage once we have all the data.
                             if(returnNumber >= listLength) {
-                                _setLocalStorage(resources, properties);
+                                _setLocalStorage(resources, properties, datatypes);
                             }
                         }, function() {
                             returnNumber++;
@@ -219,6 +270,7 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         else {
             vocabResourceData = localStorageService.get("resourceReference");
             vocabPropertyData = localStorageService.get("propertyReference");
+            vocabDatatypeData = localStorageService.get("datatypeReference");
         }
     };
 

--- a/source/assets/js/modules/profile/services/vocab.service.js
+++ b/source/assets/js/modules/profile/services/vocab.service.js
@@ -189,8 +189,22 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         return item.promise;
     };
 
+    // Method to removed extra whitespace from labels and comments.
+    var cleanVocabs = function(oType) {
+        oType.forEach(function(r) {
+            r.value.forEach(function(d) {
+                d.label = d.label.replace(/\s+/g,' ');
+                d.comment = d.comment.replace(/\s+/g,' ');
+            })
+        });
+    }
+
     // Method to set the local storage of resource and properties
     var _setLocalStorage = function(resources, properties, datatypes) {
+        cleanVocabs(resources);
+        cleanVocabs(properties);
+        cleanVocabs(datatypes);
+
         localStorageService.set("resourceReference", resources);
         localStorageService.set("propertyReference", properties);
         localStorageService.set("datatypeReference", datatypes);

--- a/source/assets/js/modules/profile/services/vocab.service.js
+++ b/source/assets/js/modules/profile/services/vocab.service.js
@@ -303,10 +303,16 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
      */
     vocab.updateChosenProperty = function(item) {
         choosenProperty = item;
-
         vocab.fillData = fillProperty;
 
         return vocabPropertyData;
+    };
+
+    vocab.updateChosenDatatype = function(item) {
+        choosenDatatype = item;
+        vocab.fillData = fillDatatype;
+
+        return vocabDatatypeData;
     };
     
     vocab.getLanguages = function() {
@@ -359,7 +365,6 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         resource.resourceURI = vocab.uri;
         resource.resourceLabel = vocab.label;
         resource.remark = vocab.comment;
-
     };
 
     fillProperty = function(vocab) {
@@ -367,7 +372,13 @@ angular.module('locApp.modules.profile.services').factory('Vocab', function($q, 
         property.propertyURI = vocab.uri;
         property.propertyLabel = vocab.label;
         property.remark = vocab.comment;
+    };
 
+    fillDatatype = function(vocab) {
+        var datatype = choosenDatatype;
+        datatype.dataTypeURI = vocab.uri;
+        datatype.dataTypeLabel = vocab.label;
+        datatype.remark = vocab.comment;
     };
 
     return vocab;

--- a/source/html/valueDataType.html
+++ b/source/html/valueDataType.html
@@ -58,7 +58,7 @@
     
 </div>
 
-<div id="chooseResource" sss-closeChooseResource class="modal modal-styled fade in" aria-hidden="true" style="display: none">
+<div id="chooseDatatype" sss-closeChooseResource class="modal modal-styled fade in" aria-hidden="true" style="display: none">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/source/html/valueDataType.html
+++ b/source/html/valueDataType.html
@@ -12,6 +12,11 @@
                         popover="URI associated with the DataType"
                         popover-title="Data Type URI" popover-trigger="mouseenter"
                         popover-placement="right"/>
+
+                    <a id="datatypeChoose" data-toggle="modal" href="#chooseDatatype" ng-click="updateChosenResource(resourceTemplate, parentList);" onclick="event.returnValue = false; return false;">
+                        <i class="fa fa-bars" style="margin-right: 10px;"></i>
+                        {{!resourceTemplate.resourceURI ? "Select Resource" : "Change Resource" }}
+                    </a>
                     
                     <div class="error" ng-show="propertyForm.dataTypeURI.$dirty && propertyForm.dataTypeURI.$invalid">
                         <small class="error">url is invalid</small>
@@ -51,4 +56,36 @@
         </tbody>
     </table>
     
+</div>
+
+<div id="chooseResource" sss-closeChooseResource class="modal modal-styled fade in" aria-hidden="true" style="display: none">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button id="chooserClose" type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
+                <h3 class="modal-title">{{vocabHeader || "Chose Vocab Template"}}</h3>
+            </div>
+            <div class="modal-body">
+                <!--Put the select in a div so that ff styles it correctly-->
+                <div id="select_box_holder">
+                    <select name="chooseVocab" ng-options="option.value as option.key for option in selectData"
+                        ng-model="sssSelected" ng-change="selectVocab();" class="form-control">
+                        <option value="" selected>Select Vocabulary File</option>
+                    </select>
+                </div>
+                
+                <form class="mainnav-form vocab-search" id="template_search_bar" role="search">
+                    <input type="text" name="search" class="form-control input-md mainnav-search-query" ng-model="searchText" placeholder="Search"/>
+                    <button ng-click="searchVocab()" class="btn btn-sm mainnav-form-btn">
+                        <i class="fa fa-search"></i>
+                    </button>
+                </form>
+                <select multiple id="resourcePick" name="chooseResource" class="form-control" ng-options="vocab as vocab.label for vocab in vocabData" ng-model="sssVocab" ng-change="fillData();">
+                        </select>
+            </div>
+            <div class="modal-footer">
+                
+            </div>
+        </div>
+    </div>
 </div>

--- a/source/html/valueDataType.html
+++ b/source/html/valueDataType.html
@@ -14,7 +14,7 @@
 
                     <a id="datatypeChoose" data-toggle="modal" href="#chooseResource" ng-click="updateChosenDatatype(valueDataType);" onclick="event.returnValue = false; return false;">
                         <i class="fa fa-bars" style="margin-right: 10px;"></i>
-                        {{!resourceTemplate.resourceURI ? "Select Resource" : "Change Resource" }}
+                        {{!valueDataType.dataTypeURI ? "Select Data Type" : "Change Data Type" }}
                     </a>
                     
                     <div class="error" ng-show="propertyForm.dataTypeURI.$dirty && propertyForm.dataTypeURI.$invalid">

--- a/source/html/valueDataType.html
+++ b/source/html/valueDataType.html
@@ -1,6 +1,5 @@
 <div ng-controller="ValueDataTypeController">
     <h5>Value Data Type</h5>
-    
     <table>
         <tbody>
             <tr>
@@ -13,7 +12,7 @@
                         popover-title="Data Type URI" popover-trigger="mouseenter"
                         popover-placement="right"/>
 
-                    <a id="datatypeChoose" data-toggle="modal" href="#chooseDatatype" ng-click="updateChosenResource(resourceTemplate, parentList);" onclick="event.returnValue = false; return false;">
+                    <a id="datatypeChoose" data-toggle="modal" href="#chooseResource" ng-click="updateChosenDatatype(valueDataType);" onclick="event.returnValue = false; return false;">
                         <i class="fa fa-bars" style="margin-right: 10px;"></i>
                         {{!resourceTemplate.resourceURI ? "Select Resource" : "Change Resource" }}
                     </a>
@@ -56,36 +55,4 @@
         </tbody>
     </table>
     
-</div>
-
-<div id="chooseDatatype" sss-closeChooseResource class="modal modal-styled fade in" aria-hidden="true" style="display: none">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <button id="chooserClose" type="button" class="close" data-dismiss="modal" aria-hidden="true">x</button>
-                <h3 class="modal-title">{{vocabHeader || "Chose Vocab Template"}}</h3>
-            </div>
-            <div class="modal-body">
-                <!--Put the select in a div so that ff styles it correctly-->
-                <div id="select_box_holder">
-                    <select name="chooseVocab" ng-options="option.value as option.key for option in selectData"
-                        ng-model="sssSelected" ng-change="selectVocab();" class="form-control">
-                        <option value="" selected>Select Vocabulary File</option>
-                    </select>
-                </div>
-                
-                <form class="mainnav-form vocab-search" id="template_search_bar" role="search">
-                    <input type="text" name="search" class="form-control input-md mainnav-search-query" ng-model="searchText" placeholder="Search"/>
-                    <button ng-click="searchVocab()" class="btn btn-sm mainnav-form-btn">
-                        <i class="fa fa-search"></i>
-                    </button>
-                </form>
-                <select multiple id="resourcePick" name="chooseResource" class="form-control" ng-options="vocab as vocab.label for vocab in vocabData" ng-model="sssVocab" ng-change="fillData();">
-                        </select>
-            </div>
-            <div class="modal-footer">
-                
-            </div>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
I have half of C.3.1.3 working.  This is the part that fills in the data type URI (also label and remark fields.)  It leverages the Vocab service, since datatypes are defined there.  Here's some points:

1) A "Select Data Type" link with the 3 bars icon is to the right of the URI input box (this resembles the "Select resource/property" links.)
2) When you click the link this opens the vocabulary list modal-- just like selecting resources or properties.
3) The user then chooses a vocabulary file (probably bad wordage here, since we no longer store the vocabs in files.)
4) The user can then choose the proper datatype from the list which will then populate the input box.
5) The Label and Remarks boxes will also get populated if appropriate.

NOTE: I noticed some new line chars in the MADSRDF labels, so I filed a bug with myself to clean that up.

I will start work on the 2nd part of C.3.1.3-- validating values in the value constraint sections-- on Monday.