### PR TITLE
Defaults array

### DIFF
--- a/source/assets/css/profileTemplate.css
+++ b/source/assets/css/profileTemplate.css
@@ -296,7 +296,7 @@ div.page-footer div.page-info {
 @media (max-width: 767px) {
     #search_bar {
         position: absolute;
-        //top: 44em;
+        /* top: 44em; */
         top: 9.8em;
         left: 2.4em;
     }
@@ -344,7 +344,7 @@ div.page-footer div.page-info {
 }
 
 .popover {
-    //min-width: 100px;
+    /* min-width: 100px; */
     max-width: 250px;
     width: auto;
 }
@@ -408,7 +408,7 @@ td label {
 }
 
 #wrapper {
-    //max-width: 1583px;
+    /* max-width: 1583px; */
     margin-left: 0px;
 }
 
@@ -512,4 +512,8 @@ div[id^=resourceTemplates] {
 
 div#deleteModal div.modal-body {
     text-align: center;
+}
+
+[name="defaultLiteral"].ng-invalid {
+    color: red;
 }

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -143,6 +143,6 @@ angular.module('locApp.modules.profile.controllers')
          * Deletes a defaults row
          */
         $scope.deleteDefault = function(index) {
-            $scope.valueConstraint.defaults.splice(index);
+            $scope.valueConstraint.defaults.splice(index,1);
         };
     });

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -51,6 +51,18 @@ angular.module('locApp.modules.profile.controllers')
             $scope.loadCount++;
         }
 
+        // create new defaults array if it doesn't exist
+        if ($scope.valueConstraint.defaults === undefined) {
+            $scope.valueConstraint.defaults = [];
+        }
+
+        // we better move the defaults data to the old model to the new one.
+        if ($scope.valueConstraint.defaultURI || $scope.valueConstraint.defaultLiteral) {
+            var defObject = { "defaultURI" : $scope.valueConstraint.defaultURI, "defaultLiteral" : $scope.valueConstraint.defaultLiteral };
+            $scope.valueConstraint.defaults[0] = defObject;
+            delete $scope.valueConstraint.defaultURI;
+            delete $scope.valueConstraint.defaultLiteral
+        }
         // Method to get the template references
         if(!$scope.selectList) {
             var rts = [];

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -123,4 +123,14 @@ angular.module('locApp.modules.profile.controllers')
             var defaults = {"defaultURI":"", "defaultLiteral":""};
             $scope.valueConstraint.defaults.push(defaults);
         };
+
+        /**
+         * @ngdoc function
+         * @name deleteDefault
+         * @description
+         * Deletes a defaults row
+         */
+        $scope.deleteDefault = function(index) {
+            $scope.valueConstraint.defaults.splice(index);
+        };
     });

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -146,3 +146,4 @@ angular.module('locApp.modules.profile.controllers')
             $scope.valueConstraint.defaults.splice(index,1);
         };
     });
+    

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -112,4 +112,15 @@ angular.module('locApp.modules.profile.controllers')
             $scope.deleteItem($scope.parentId, $scope.valueFields);
             $scope.deleteItem($scope.parentId, $scope.valueConstraint.useValuesFrom);
         };
+
+        /**
+         * @ngdoc function
+         * @name addDefault
+         * @description
+         * Adds a row to defaults 
+         */
+        $scope.addDefault = function() {
+            var defaults = {"defaultURI":"", "defaultLiteral":""};
+            $scope.valueConstraint.defaults.push(defaults);
+        };
     });

--- a/source/assets/js/modules/profile/services/profileHandler.service.js
+++ b/source/assets/js/modules/profile/services/profileHandler.service.js
@@ -14,7 +14,7 @@ angular.module('locApp.modules.profile.services')
         var profAttributes = ["id","title","description","date","contact","remark","resourceTemplates"];
         var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","contact","remark"];
         var propAttributes = ["propertyURI","propertyLabel","mandatory","repeatable","type","valueConstraint","remark", "resourceTemplates"];
-        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral"];
+        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults"];
         var dataAttributes = ["dataTypeURI","dataTypeLabel","dataTypeLabelHint","remark"];
 
         var RESOURCE_TEMPLATE = "resourceTemplates";

--- a/source/assets/js/modules/profile/services/profileHandler.service.js
+++ b/source/assets/js/modules/profile/services/profileHandler.service.js
@@ -14,7 +14,7 @@ angular.module('locApp.modules.profile.services')
         var profAttributes = ["id","title","description","date","contact","remark","resourceTemplates"];
         var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","contact","remark"];
         var propAttributes = ["propertyURI","propertyLabel","mandatory","repeatable","type","valueConstraint","remark", "resourceTemplates"];
-        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults"];
+        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults", "validatePattern"];
         var dataAttributes = ["dataTypeURI","dataTypeLabel","dataTypeLabelHint","remark"];
 
         var RESOURCE_TEMPLATE = "resourceTemplates";

--- a/source/html/valueConstraint.html
+++ b/source/html/valueConstraint.html
@@ -70,6 +70,21 @@
                     </select>
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <label for="validatePattern">Validate Pattern</label>
+                </td>
+                <td>
+                    <input name="validatePattern" ng-model="valueConstraint.validatePattern"
+                           popover="Regular expression for input validation."
+                           popover-title="Validate Pattern" popover-trigger="mouseenter"
+                           popover-placement="right"/>
+                </td>
+                <td>
+                </td>
+                <td>
+                </td>
+            </tr>
             <tr ng-repeat="d in valueConstraint.defaults">
                 <td>
                     <label for="editable">Default URI</label>
@@ -84,7 +99,7 @@
                     <label for="editable">Default Literal</label>
                 </td>
                 <td>
-                    <input name="defaultLiteral" ng-model="d.defaultLiteral"
+                    <input name="defaultLiteral" ng-model="d.defaultLiteral" ng-pattern="/{{ valueConstraint.validatePattern }}/"
                             popover="Value constraint default literal value."
                             popover-title="Default Literal" popover-trigger="mouseenter"
                             popover-placement="left"/>

--- a/source/html/valueConstraint.html
+++ b/source/html/valueConstraint.html
@@ -87,13 +87,15 @@
                     <input name="defaultLiteral" ng-model="d.defaultLiteral"
                             popover="Value constraint default literal value."
                             popover-title="Default Literal" popover-trigger="mouseenter"
-                            popover-placement="left">
-                    </select>
+                            popover-placement="left"/>
+                    <a href="#" onclick="event.returnValue = false; return false;" ng-click="deleteDefault($index)">
+                        <i class="fa fa-trash-o"></i>
+                    </a>
                 </td>
             </tr>
         </tbody>
     </table>
-    {{ valueConstraint | json}}
+    
     <a id="addDefault" ng-click="addDefault()" style="display: block;">
         <i class="fa fa-plus"></i>
         Add Default

--- a/source/html/valueConstraint.html
+++ b/source/html/valueConstraint.html
@@ -70,12 +70,12 @@
                     </select>
                 </td>
             </tr>
-            <tr>
+            <tr ng-repeat="d in valueConstraint.defaults">
                 <td>
                     <label for="editable">Default URI</label>
                 </td>
                 <td>
-                    <input name="defaultURI" ng-model="valueConstraint.defaultURI"
+                    <input name="defaultURI" ng-model="d.defaultURI"
                             popover="Value constraint default value URI."
                             popover-title="Default URI" popover-trigger="mouseenter"
                             popover-placement="right"/>
@@ -84,7 +84,7 @@
                     <label for="editable">Default Literal</label>
                 </td>
                 <td>
-                    <input name="defaultLiteral" ng-model="valueConstraint.defaultLiteral"
+                    <input name="defaultLiteral" ng-model="d.defaultLiteral"
                             popover="Value constraint default literal value."
                             popover-title="Default Literal" popover-trigger="mouseenter"
                             popover-placement="left">
@@ -93,7 +93,12 @@
             </tr>
         </tbody>
     </table>
-    
+    {{ valueConstraint | json}}
+    <a id="addDefault" ng-click="addDefault()" style="display: block;">
+        <i class="fa fa-plus"></i>
+        Add Default
+    </a>
+
     <div id="valueDataType" class="propertyItems">
         <div ng-repeat="field in constraintFields" sss-field item="{{field}}" html='html/valueDataType.html'></div>
     </div>


### PR DESCRIPTION
I needed to update the data model for the profiles to include a "defaults" array.  This array stores objects that contain the defaultURI and defaultLiteral (they need to be together!)  For this reason, my earlier textarea mock-up would not suffice.  

Instead, there is a button called "+ Add Default" which will display a table row with both the "Default URI" and "Default Literal"  input boxes.   You can add as many as you want.

The valueConstraint controller will check for the old singleton data model and convert it to the new array of objects data model (if there are values there (of course)).  The controller will also delete the singletons so there is no confusion introduced to the bfe.

I will file a pull request for the bfe shortly.