### PR TITLE
Validate pattern

### DIFF
--- a/source/assets/css/profileTemplate.css
+++ b/source/assets/css/profileTemplate.css
@@ -296,7 +296,7 @@ div.page-footer div.page-info {
 @media (max-width: 767px) {
     #search_bar {
         position: absolute;
-        //top: 44em;
+        /* top: 44em; */
         top: 9.8em;
         left: 2.4em;
     }
@@ -344,7 +344,7 @@ div.page-footer div.page-info {
 }
 
 .popover {
-    //min-width: 100px;
+    /* min-width: 100px; */
     max-width: 250px;
     width: auto;
 }
@@ -408,7 +408,7 @@ td label {
 }
 
 #wrapper {
-    //max-width: 1583px;
+    /* max-width: 1583px; */
     margin-left: 0px;
 }
 
@@ -512,4 +512,8 @@ div[id^=resourceTemplates] {
 
 div#deleteModal div.modal-body {
     text-align: center;
+}
+
+[name="defaultLiteral"].ng-invalid {
+    color: red;
 }

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/valueconstraint/controllers/valueConstraint.controller.js
@@ -146,3 +146,4 @@ angular.module('locApp.modules.profile.controllers')
             $scope.valueConstraint.defaults.splice(index,1);
         };
     });
+    

--- a/source/assets/js/modules/profile/services/profileHandler.service.js
+++ b/source/assets/js/modules/profile/services/profileHandler.service.js
@@ -14,7 +14,7 @@ angular.module('locApp.modules.profile.services')
         var profAttributes = ["id","title","description","date","contact","remark","resourceTemplates"];
         var resAttributes = ["id","resourceURI","resourceURL","resourceLabel","propertyTemplates","contact","remark"];
         var propAttributes = ["propertyURI","propertyLabel","mandatory","repeatable","type","valueConstraint","remark", "resourceTemplates"];
-        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults"];
+        var consAttributes = ["valueLanguage","languageURI","languageLabel","valueDataType","valueTemplateRefs","useValuesFrom","editable","remark", "repeatable", "defaultURI", "defaultLiteral", "defaults", "validatePattern"];
         var dataAttributes = ["dataTypeURI","dataTypeLabel","dataTypeLabelHint","remark"];
 
         var RESOURCE_TEMPLATE = "resourceTemplates";

--- a/source/html/valueConstraint.html
+++ b/source/html/valueConstraint.html
@@ -99,7 +99,7 @@
                     <label for="editable">Default Literal</label>
                 </td>
                 <td>
-                    <input name="defaultLiteral" ng-model="d.defaultLiteral"
+                    <input name="defaultLiteral" ng-model="d.defaultLiteral" ng-pattern="/{{ valueConstraint.validatePattern }}/"
                             popover="Value constraint default literal value."
                             popover-title="Default Literal" popover-trigger="mouseenter"
                             popover-placement="left"/>

--- a/source/html/valueConstraint.html
+++ b/source/html/valueConstraint.html
@@ -70,6 +70,21 @@
                     </select>
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <label for="validatePattern">Validate Pattern</label>
+                </td>
+                <td>
+                    <input name="validatePattern" ng-model="valueConstraint.validatePattern"
+                           popover="Regular expression for input validation."
+                           popover-title="Validate Pattern" popover-trigger="mouseenter"
+                           popover-placement="right"/>
+                </td>
+                <td>
+                </td>
+                <td>
+                </td>
+            </tr>
             <tr ng-repeat="d in valueConstraint.defaults">
                 <td>
                     <label for="editable">Default URI</label>


### PR DESCRIPTION
I added some minimal pattern checking.  There is a field in the profile editor under value constraints that takes a regexp.  The default literal values are also matched to it so that a new default literal cannot be invalid.  The text will be red until the value is match against the pattern.  If you click save on an invalid default literal the ng-invalid process kicks in and blocks the save.

I will merge this in the defaults-array branch.