### PR TITLE
C314

### DIFF
--- a/source/assets/js/modules/profile/controllers/profile.controller.js
+++ b/source/assets/js/modules/profile/controllers/profile.controller.js
@@ -28,6 +28,7 @@ angular.module('locApp.modules.profile.controllers')
         $scope.profile = {};
         $scope.profile.resourceTemplates = [];
         $scope.resourceTemplatesBase = [];
+        $scope.propertyTypes = [];
 
         $scope.oldTitle = "";
         $scope.searchText = "";
@@ -103,6 +104,12 @@ angular.module('locApp.modules.profile.controllers')
                     $scope.titleList.push(response[i].json.Profile.title);
                     $scope.idList.push(response[i].id);
                 }
+            });
+
+        // Get propertyTypes
+        Server.get('/verso/api/configs?filter[where][name]=propertyTypes', {}, true)
+            .then(function(response) {
+                $scope.propertyTypes = response[0].json;
             });
 
         /**

--- a/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
@@ -5,7 +5,7 @@
  * handles the scope variable for resource templates
  */
 angular.module('locApp.modules.profile.controllers')
-    .controller('resourceTemplateController', function($scope, Vocab, Scrub) {
+    .controller('resourceTemplateController', function($scope, Scrub, localStorageService) {
         $scope.resourceFields = [];
         $scope.resourceTemplate = {};
         $scope.addIndexResource = 0;
@@ -124,6 +124,20 @@ angular.module('locApp.modules.profile.controllers')
             },
             distance: '10'
         };
+
+        /**
+         * @ngdoc function
+         * @name checkID
+         * @description
+         * Check if the template id is unique
+         */
+        $scope.checkID = function() {
+            $scope.resourceForm.resourceId.$invalid = false;
+            var templateRefs = localStorageService.get('templateRefs');
+            templateRefs.find(function (t) {
+                if (t == $scope.resourceTemplate.id) {
+                    $scope.resourceForm.resourceId.$invalid = true;
+                };
+            });
+        };
     });
-
-

--- a/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
@@ -5,7 +5,7 @@
  * handles the scope variable for resource templates
  */
 angular.module('locApp.modules.profile.controllers')
-    .controller('resourceTemplateController', function($scope, Scrub, localStorageService) {
+    .controller('resourceTemplateController', function($scope, Scrub, localStorageService, $http) {
         $scope.resourceFields = [];
         $scope.resourceTemplate = {};
         $scope.addIndexResource = 0;
@@ -138,6 +138,24 @@ angular.module('locApp.modules.profile.controllers')
                 if (t == $scope.resourceTemplate.id) {
                     $scope.resourceForm.resourceId.$invalid = true;
                 };
+            });
+        };
+
+        /**
+         * @ngdoc function
+         * @name checkURI
+         * @description
+         * Check if URI resolves
+         */
+        $scope.checkURI = function() {
+            var url = 'server/whichrt?uri=' + $scope.resourceTemplate.resourceURI;
+            $http({
+                method: 'HEAD',
+                url: url
+            })
+            .then(function (response) {
+            }, function (response) {
+                console.log($scope.resourceTemplate.resourceURI + ' did not resolve!')
             });
         };
     });

--- a/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/controllers/resourceTemplate.controller.js
@@ -148,6 +148,7 @@ angular.module('locApp.modules.profile.controllers')
          * Check if URI resolves
          */
         $scope.checkURI = function() {
+            $scope.resourceForm.resourceURI.$warn = false;
             var url = 'server/whichrt?uri=' + $scope.resourceTemplate.resourceURI;
             $http({
                 method: 'HEAD',
@@ -156,6 +157,7 @@ angular.module('locApp.modules.profile.controllers')
             .then(function (response) {
             }, function (response) {
                 console.log($scope.resourceTemplate.resourceURI + ' did not resolve!')
+                $scope.resourceForm.resourceURI.$warn = true;
             });
         };
     });

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/controllers/propertyTemplate.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/controllers/propertyTemplate.controller.js
@@ -17,7 +17,7 @@ angular.module('locApp.modules.profile.controllers')
         $scope.resources = [];
         $scope.propResourceBase = [];
         $scope.addIndexProperty = 0;
-        
+
         $scope.resNest = $scope.getResNest();
         
         // Logic for creating/retreveing object

--- a/source/assets/js/modules/profile/resourcetemplate/propertytemplate/controllers/propertyTemplate.controller.js
+++ b/source/assets/js/modules/profile/resourcetemplate/propertytemplate/controllers/propertyTemplate.controller.js
@@ -5,7 +5,7 @@
  * Handles the scope variable for property templates
 */
 angular.module('locApp.modules.profile.controllers')
-    .controller('propertyTemplateController', function($scope, $state, $stateParams, Scrub) {
+    .controller('propertyTemplateController', function($scope, $state, $stateParams, Scrub, $http) {
         $scope.propertyFields = [];
         $scope.propertyTemplate = {
             mandatory:  'false',
@@ -112,6 +112,26 @@ angular.module('locApp.modules.profile.controllers')
                 $scope.propertyTemplate.resourceTemplates = $scope.rearrangeData($scope.resources, $scope.propResourceBase);
             },
             distance: '10'
+        };
+
+        /**
+         * @ngdoc function
+         * @name checkPropertyURI
+         * @description
+         * Check if the property URI resolves
+         */
+        $scope.checkPropertyURI = function() {
+            $scope.propertyForm.propertyURI.$warn = false;
+            var url = 'server/whichrt?uri=' + $scope.propertyTemplate.propertyURI;
+            $http({
+                method: 'HEAD',
+                url: url
+            })
+            .then(function (response) {
+            }, function (response) {
+                console.log($scope.propertyTemplate.propertyURI + ' did not resolve!')
+                $scope.propertyForm.propertyURI.$warn = true;
+            });
         };
         
     });

--- a/source/assets/js/modules/profile/services/httpResponse.service.js
+++ b/source/assets/js/modules/profile/services/httpResponse.service.js
@@ -33,6 +33,10 @@ angular.module('locApp.modules.profile.services')
         responseService.responseError = function(rejection) {
             //watched by the alert directive to know when to show messages
             console.log(rejection);
+            if (rejection.message === undefined && rejection.status !== undefined) {
+                var url = rejection.config.url.replace(/.+uri=/,'');
+                rejection.message = 'There was a problem loading ' + url + ' (' + rejection.status + ' ' + rejection.statusText + ')';
+            }
             if(rejection.message.match(/Syntax error/) || rejection.message.match(/Unexpected token/) || rejection.message.match(/JSON.parse/)) {
                 responseService.alertError = !responseService.alertError;
                 responseService.errorMessage = "There was an error parsing the response. Please review the file and try again.";

--- a/source/assets/js/modules/profile/services/httpResponse.service.js
+++ b/source/assets/js/modules/profile/services/httpResponse.service.js
@@ -33,10 +33,6 @@ angular.module('locApp.modules.profile.services')
         responseService.responseError = function(rejection) {
             //watched by the alert directive to know when to show messages
             console.log(rejection);
-            if (rejection.message === undefined && rejection.status !== undefined) {
-                var url = rejection.config.url.replace(/.+uri=/,'');
-                rejection.message = 'There was a problem loading ' + url + ' (' + rejection.status + ' ' + rejection.statusText + ')';
-            }
             if(rejection.message.match(/Syntax error/) || rejection.message.match(/Unexpected token/) || rejection.message.match(/JSON.parse/)) {
                 responseService.alertError = !responseService.alertError;
                 responseService.errorMessage = "There was an error parsing the response. Please review the file and try again.";

--- a/source/html/propertyTemplate.html
+++ b/source/html/propertyTemplate.html
@@ -62,10 +62,12 @@
                         <label for="type">Type</label>
                     </td>
                     <td>
-                        <input name="type" ng-model="propertyTemplate.type"
+                        <select name="type" ng-model="propertyTemplate.type"
+                               ng-options="item for item in propertyTypes"
                                popover="Type or value that is allowed by this property."
                                popover-title="Type" popover-trigger="mouseenter"
-                               popover-placement="right"/>
+                               popover-placement="right">
+                        </select>
                     </td>
                     <td>
                         <label for="remark">Guiding statement for the use of this resource</label>

--- a/source/html/propertyTemplate.html
+++ b/source/html/propertyTemplate.html
@@ -33,6 +33,7 @@
                     </td>
                     <td>
                         <input type="url" name="propertyURI" ng-model="propertyTemplate.propertyURI" required
+                               ng-blur="checkPropertyURI()"
                                popover="URI of the RDF property being described"
                                popover-title="Property URI" popover-trigger="mouseenter"
                                popover-placement="right"/>
@@ -41,7 +42,10 @@
                         </div>
                         <div class="error" ng-show="!propertyForm.propertyURI.$error.required && propertyForm.propertyURI.$dirty && propertyForm.propertyURI.$invalid">
                            <small class="error">url is invalid</small>
-                        </div> 
+                        </div>
+                        <div class="warn" ng-show="propertyForm.propertyURI.$warn">
+                            <small class="fa fa-warning red">URI did not resolve!</small>
+                        </div>
                     </td>
                     <td>
                         <label for="propertyLabel">Property Label</label>

--- a/source/html/resourceTemplate.html
+++ b/source/html/resourceTemplate.html
@@ -30,10 +30,13 @@
                         <label for="id">ID</label>
                     </td>
                     <td>
-                        <input name="resourceId" ng-model="resourceTemplate.id"
+                        <input name="resourceId" ng-model="resourceTemplate.id" ng-change="checkID()" required
                                popover="Identifier associated with a resource template"
                                popover-title="Resource ID" popover-trigger="mouseenter"
                                popover-placement="right"/>
+                        <div class="error" ng-show="resourceForm.resourceId.$invalid">
+                            <small class="error">Not unique</small>
+                        </div>
                     </td>
 
                     <td>

--- a/source/html/resourceTemplate.html
+++ b/source/html/resourceTemplate.html
@@ -44,6 +44,7 @@
                     </td>
                     <td>
                        <input  type="url" name="resourceURI" ng-model="resourceTemplate.resourceURI" required
+                               ng-blur="checkURI()"
                                popover="URI of the RDF resource associated with the resource template"
                                popover-title="Resource URI" popover-trigger="mouseenter"
                                popover-placement="left"/>

--- a/source/html/resourceTemplate.html
+++ b/source/html/resourceTemplate.html
@@ -35,7 +35,7 @@
                                popover-title="Resource ID" popover-trigger="mouseenter"
                                popover-placement="right"/>
                         <div class="error" ng-show="resourceForm.resourceId.$invalid">
-                            <small class="error">Not unique</small>
+                            <small class="error">ID not unique</small>
                         </div>
                     </td>
 
@@ -43,7 +43,7 @@
                         <label for="resourceURI">Resource URI</label>
                     </td>
                     <td>
-                       <input  type="url" name="resourceURI" ng-model="resourceTemplate.resourceURI" required
+                        <input  type="url" name="resourceURI" ng-model="resourceTemplate.resourceURI" required
                                ng-blur="checkURI()"
                                popover="URI of the RDF resource associated with the resource template"
                                popover-title="Resource URI" popover-trigger="mouseenter"
@@ -51,9 +51,12 @@
                         <div class="error" style="display: inline-block;" ng-show="resourceForm.resourceURI.$error.required">
                             <i class="fa fa-warning red"></i>
                         </div>
-                       <div class="error" ng-show="!resourceForm.resourceURI.$error.required && resourceForm.resourceURI.$dirty && resourceForm.resourceURI.$invalid">
-                           <small class="error">uri is invalid</small>
-                       </div>
+                        <div class="error" ng-show="!resourceForm.resourceURI.$error.required && resourceForm.resourceURI.$dirty && resourceForm.resourceURI.$invalid">
+                             <small class="error">uri is invalid</small>
+                        </div>
+                        <div class="warn" ng-show="resourceForm.resourceURI.$warn">
+                            <small class="fa fa-warning red">URI did not resolve!</small>
+                        </div>
                     </td>
                 </tr>
 


### PR DESCRIPTION
Ok, I forgot about the validation stuff for the profile editor.

* The user gets a warning when the resource ID is not unique
* URI resolution checking is performed on resource URI and property URI fields.  If the response is not 'OK'  the error modal appears describing the problem.  Also, there will be a little warning message below the input box that will stay visible.  This happens after moving away from the URI input boxes (on blur as it were.)
* The property types are now stored in verso and populate a select box with the five valid property types.  Currently the selections will need to be edited via the verso api. (perhaps in the following weeks we could add a settings section that deals with configs).  There is a load-type.js script that I pushed to verso.  It will load the types upon booting the server.
